### PR TITLE
Make GitHub detect *.hfs as Forth

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.hfs linguist-language=Forth


### PR DESCRIPTION
Hello,

Your `.hfs` files are not recognized by GitHub.  There are several ways to fix this, so here is a suggestion to change the file extension to `.fth`.  After this change, your repository is classified as Forth.
